### PR TITLE
Solved seminars

### DIFF
--- a/week3-layers-and_architectures/Layers & Architectures.ipynb
+++ b/week3-layers-and_architectures/Layers & Architectures.ipynb
@@ -44,7 +44,7 @@
     {
      "data": {
       "text/plain": [
-       "tensor([2., 0., 2., 0., 2., 2., 0., 2., 0., 2.])"
+       "tensor([0., 0., 0., 0., 0., 0., 2., 2., 2., 2.])"
       ]
      },
      "execution_count": 2,
@@ -146,9 +146,10 @@
     "            \n",
     "            self.running_mean = self.momentum * mean + (1. - self.momentum) * self.running_mean\n",
     "            self.running_var = self.momentum * var + (1. - self.momentum) * self.running_var\n",
+    "            var = x_ch.var(1, unbiased=False)[:, None, None]\n",
     "        else:\n",
     "            mean = self.running_mean\n",
-    "            var = self.running_std\n",
+    "            var = self.running_var\n",
     "            \n",
     "        x = (x - mean) / (torch.sqrt(var + self.eps))\n",
     "        return self.gamma * x + self.beta"
@@ -179,15 +180,22 @@
     "assert approx_eq(bn.running_mean, bn_torch.running_mean)\n",
     "assert torch.all(bn.gamma == bn_torch.weight)\n",
     "assert torch.all(bn.beta == bn_torch.bias)\n",
-    "assert approx_eq(normed, normed_torch, eps=10)"
+    "assert approx_eq(normed, normed_torch, eps=1e-3)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "bn.eval()\n",
+    "bn_torch.eval()\n",
+    "\n",
+    "normed = bn(t)\n",
+    "normed_torch = bn_torch(t)\n",
+    "assert approx_eq(normed, normed_torch, eps=1e-3)"
+   ]
   },
   {
    "cell_type": "code",
@@ -1898,7 +1906,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
torch var uses Bessel’s correction by default. That is why bn didn't work properly